### PR TITLE
[fix] Auth - 회원가입 API 연동 (#101)

### DIFF
--- a/data/src/main/java/com/yangbong/data/remote/model/request/LoginRequest.kt
+++ b/data/src/main/java/com/yangbong/data/remote/model/request/LoginRequest.kt
@@ -3,9 +3,9 @@ package com.yangbong.data.remote.model.request
 import com.google.gson.annotations.SerializedName
 
 data class LoginRequest(
+    @SerializedName("platform")
+    val platform: String,
     @SerializedName("socialToken")
-    val socialToken: String,
-    @SerializedName("fcmToken")
-    val fcmToken: String,
+    val socialToken: String
 )
 

--- a/data/src/main/java/com/yangbong/data/remote/model/response/BaseResponse.kt
+++ b/data/src/main/java/com/yangbong/data/remote/model/response/BaseResponse.kt
@@ -3,12 +3,12 @@ package com.yangbong.data.remote.model.response
 import com.google.gson.annotations.SerializedName
 
 data class BaseResponse<T>(
-    @SerializedName("data")
-    val `data`: T,
-    @SerializedName("message")
-    val message: String,
     @SerializedName("status")
     val status: Int,
-    @SerializedName("success")
-    val success: Boolean
+    @SerializedName("code")
+    val code: Int,
+    @SerializedName("message")
+    val message: String,
+    @SerializedName("data")
+    val `data`: T
 )

--- a/data/src/main/java/com/yangbong/data/remote/model/response/LoginResponse.kt
+++ b/data/src/main/java/com/yangbong/data/remote/model/response/LoginResponse.kt
@@ -4,9 +4,10 @@ package com.yangbong.data.remote.model.response
 import com.google.gson.annotations.SerializedName
 
 data class LoginResponse(
-    @SerializedName("jwtToken")
+    @SerializedName("jwt")
     val jwtToken: String,
-    @SerializedName("isNewUser")
-    val isNewUser: Boolean
+    @SerializedName("isnewuser")
+    val isNewUser: Boolean,
+    @SerializedName("message")
+    val message: String
 )
-

--- a/data/src/main/java/com/yangbong/data/remote/service/LoginService.kt
+++ b/data/src/main/java/com/yangbong/data/remote/service/LoginService.kt
@@ -5,11 +5,11 @@ import com.yangbong.data.remote.model.request.LoginRequest
 import com.yangbong.data.remote.model.response.BaseResponse
 import com.yangbong.data.remote.model.response.LoginResponse
 import retrofit2.http.Body
-import retrofit2.http.POST
+import retrofit2.http.PUT
 
 interface LoginService {
 
-    @POST("user/login")
+    @PUT("v1/auth/login")
     suspend fun postLogin(
         @Body body: LoginRequest
     ): NetworkState<BaseResponse<LoginResponse>>

--- a/data/src/main/java/com/yangbong/data/repository/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/yangbong/data/repository/LoginRepositoryImpl.kt
@@ -48,8 +48,8 @@ class LoginRepositoryImpl @Inject constructor(
     override suspend fun postLogin(loginRequest: DomainLoginRequest): Result<DomainLoginResponse> {
         val response = remoteLoginDataSource.postLogin(
             LoginRequest(
-                socialToken = loginRequest.socialToken,
-                fcmToken = loginRequest.fcmToken
+                platform = loginRequest.platform,
+                socialToken = loginRequest.socialToken
             )
         )
 

--- a/domain/src/main/java/com/yangbong/domain/entity/request/DomainLoginRequest.kt
+++ b/domain/src/main/java/com/yangbong/domain/entity/request/DomainLoginRequest.kt
@@ -2,6 +2,5 @@ package com.yangbong.domain.entity.request
 
 data class DomainLoginRequest(
     val platform: String,
-    val socialToken: String,
-    val fcmToken: String
+    val socialToken: String
 )

--- a/feature/auth/src/main/java/com/yangbong/auth/login/LoginFragment.kt
+++ b/feature/auth/src/main/java/com/yangbong/auth/login/LoginFragment.kt
@@ -2,7 +2,7 @@ package com.yangbong.auth.login
 
 import android.os.Bundle
 import android.view.View
-import android.view.animation.AnimationUtils
+import android.widget.Toast
 import androidx.fragment.app.activityViewModels
 import com.yangbong.auth.social_login_manager.KakaoLoginManager
 import com.yangbong.core_ui.base.BindingFragment
@@ -23,7 +23,7 @@ class LoginFragment : BindingFragment<FragmentLoginBinding>(R.layout.fragment_lo
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        loginViewModel.getFcmToken()
+//        loginViewModel.getFcmToken()
         initClickEvent()
         initLoginObserver()
         initLoginFailureMessageObserver()
@@ -53,15 +53,8 @@ class LoginFragment : BindingFragment<FragmentLoginBinding>(R.layout.fragment_lo
     }
 
     private fun initLoginFailureMessageObserver() {
-        /**
-         * @author onseok
-         * 서버가 아직 구현되지 않았기 때문에, 로그인 실패해도 임시로 프로필 설정 화면으로 넘어가도록 구현하였습니다.
-         */
-//        loginViewModel.loginFailureMessage.observe(viewLifecycleOwner) {
-//            Toast.makeText(requireContext(), "로그인에 실패 하였습니다", Toast.LENGTH_SHORT).show()
-//        }
         loginViewModel.loginFailureMessage.observe(viewLifecycleOwner) {
-            navigateSetProfileActivity()
+            Toast.makeText(requireContext(), "로그인에 실패 하였습니다", Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/feature/auth/src/main/java/com/yangbong/auth/login/LoginViewModel.kt
+++ b/feature/auth/src/main/java/com/yangbong/auth/login/LoginViewModel.kt
@@ -20,8 +20,8 @@ class LoginViewModel @Inject constructor(
     private val _socialToken = MutableLiveData<String>()
     val socialToken: LiveData<String> = _socialToken
 
-    private val _fcmToken = MutableLiveData<String>()
-    val fcmToken: LiveData<String> = _fcmToken
+//    private val _fcmToken = MutableLiveData<String>()
+//    val fcmToken: LiveData<String> = _fcmToken
 
     private val _profileImageUrl = MutableLiveData<String>()
     val profileImageUrl: LiveData<String> = _profileImageUrl
@@ -42,20 +42,18 @@ class LoginViewModel @Inject constructor(
             loginUseCases.postLogin(
                 DomainLoginRequest(
                     platform = platform,
-                    socialToken = socialToken.value ?: "",
-                    fcmToken = fcmToken.value ?: ""
+                    socialToken = socialToken.value ?: ""
                 )
             ).onSuccess {
                 if (it.isNewUser) {
                     _navigateToSetProfile.postValue(Event(platform))
+                    loginUseCases.saveUserProfileImageUrl(profileImageUrl.value ?: "")
                 } else {
                     loginUseCases.saveAccessToken(it.accessToken ?: "")
                     _navigateToHome.postValue(Event(true))
                 }
             }.onFailure {
-                loginUseCases.saveUserProfileImageUrl(profileImageUrl.value ?: "")
                 _loginFailureMessage.postValue(it.message)
-                // TODO("서버 연동이 완료되면 아래의 로직은 onSuccess로 이동하기")
             }
         }
     }
@@ -75,14 +73,14 @@ class LoginViewModel @Inject constructor(
         _profileImageUrl.value = profileImageUrl
     }
 
-    fun getFcmToken() {
-        loginUseCases.getFcmToken {
-            updateFcmToken(it)
-        }
-    }
+//    fun getFcmToken() {
+//        loginUseCases.getFcmToken {
+//            updateFcmToken(it)
+//        }
+//    }
 
-    private fun updateFcmToken(fcmToken: String) {
-        _fcmToken.value = fcmToken
-    }
+//    private fun updateFcmToken(fcmToken: String) {
+//        _fcmToken.value = fcmToken
+//    }
 
 }


### PR DESCRIPTION
## 관련 이슈번호
- #101 

## 작업 사항
- 회원가입 API를 연동하기 위해 데이터, 도메인 계층의 엔티티를 수정하였습니다.
- 로그인 화면에서 fcm 토큰을 저장하고 서버에 보내는 로직을 삭제하였습니다. (프로필 설정 화면에서 보내는 것으로 변경됨.)

close #101 