### PR TITLE
[hotfix] 캐릭터 선택 화면 관련 빌드 에러 수정 🚒 

### DIFF
--- a/feature/set-character/src/main/java/com/yangbong/set_character/ui/SetCharacterActivity.kt
+++ b/feature/set-character/src/main/java/com/yangbong/set_character/ui/SetCharacterActivity.kt
@@ -9,7 +9,7 @@ import com.yangbong.damedame.set_character.databinding.ActivitySetCharacterBindi
 import dagger.hilt.android.AndroidEntryPoint
 import com.yangbong.damedame.set_character.R
 import com.yangbong.set_character.CharacterData
-import com.yangbong.set_character.view.SelectedCharacterSheetDialog
+import com.yangbong.set_character.view.CharacterInfoBottomSheetDialog
 import com.yangbong.set_character.SetCharacterAdapter
 
 @AndroidEntryPoint
@@ -34,7 +34,7 @@ class SetCharacterActivity :
         adapter = SetCharacterAdapter(characterData)
         adapter.itemClickListener = object : SetCharacterAdapter.OnItemClickListener {
             override fun OnItemClick(data: CharacterData, imageView: ImageView) {
-                SelectedCharacterSheetDialog(
+                CharacterInfoBottomSheetDialog(
                     onSelectClick = ::postCharacterInfo
                 ).show(
                     supportFragmentManager,

--- a/feature/set-character/src/main/java/com/yangbong/set_character/view/CharacterInfoBottomSheetDialog.kt
+++ b/feature/set-character/src/main/java/com/yangbong/set_character/view/CharacterInfoBottomSheetDialog.kt
@@ -5,24 +5,29 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
-import com.yangbong.damedame.shared.databinding.LayoutSelectedCharacterSheetBinding
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.yangbong.damedame.set_character.databinding.LayoutCharacterInfoBottomSheetBinding
 import com.yangbong.damedame.shared.R
 
-class SelectedCharacterSheetDialog(
+class CharacterInfoBottomSheetDialog(
     private val onSelectClick: () -> Unit,
-) :BottomSheetDialogFragment() {
-    private var _binding: LayoutSelectedCharacterSheetBinding? = null
-    protected val binding: LayoutSelectedCharacterSheetBinding
+) : BottomSheetDialogFragment() {
+    private var _binding: LayoutCharacterInfoBottomSheetBinding? = null
+    protected val binding: LayoutCharacterInfoBottomSheetBinding
         get() = requireNotNull(_binding)
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         _binding =
-            DataBindingUtil.inflate(inflater,R.layout.layout_selected_character_sheet,container,false)
+            DataBindingUtil.inflate(
+                inflater,
+                com.yangbong.damedame.set_character.R.layout.layout_character_info_bottom_sheet,
+                container,
+                false
+            )
         binding.lifecycleOwner = viewLifecycleOwner
         return binding.root
     }
@@ -33,7 +38,7 @@ class SelectedCharacterSheetDialog(
     }
 
     private fun onSelectClickListener() {
-        binding.selectBtn.setOnClickListener {
+        binding.btnSelect.setOnClickListener {
             onSelectClick.invoke()
             dismiss()
         }


### PR DESCRIPTION
## 관련 이슈번호
- #126 

## 작업 사항
- 캐릭터 정보 바텀 시트 다이얼로그 네이밍으로 인한 빌드 에러를 수정하였습니다.

close #126 